### PR TITLE
Explicitly add request as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "homepage": "https://github.com/pradel/node-instagram#readme",
   "dependencies": {
     "lodash.isfunction": "^3.0.8",
+    "request": "^2.34",
     "request-promise": "^4.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
request-promise no longer ships with request (it's now a peer dependency)